### PR TITLE
Add metal storage blocks as beacon base blocks

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/beacon_base_blocks.json
+++ b/src/main/resources/data/minecraft/tags/blocks/beacon_base_blocks.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "eidolon:lead_block",
+    "eidolon:pewter_block",
+    "eidolon:arcane_gold_block"
+  ]
+}


### PR DESCRIPTION
These metals are on par with iron if not higher quality. This adds feature parity with mods such as Create and Tinker's Construct, which also add their metal storage blocks as beacon base blocks.
